### PR TITLE
Create empty corpus folders in remote scripts if missing

### DIFF
--- a/scripts/remote_go.py
+++ b/scripts/remote_go.py
@@ -10,7 +10,6 @@ RELEASE_FOLDER = os.path.join(REPO_PATH, "Release")
 REMOTE_FOLDER = os.path.join(REPO_PATH, "Remote")
 OUTPUT_FOLDER = "./corpus/GO"
 
-os.makedirs(OUTPUT_FOLDER, exist_ok=True)
 
 def convert_lang(lang: str) -> str:
     match lang:
@@ -36,9 +35,10 @@ print(f'Checking if repository is up to date...')
 subprocess.run(['git', 'pull'], cwd=REPO_PATH, check=True)
 
 # Check modified time
-latest_src = max(os.path.getmtime(path) for path in glob.iglob(os.path.join(REPO_PATH, '**/*.json'), recursive=True))
-output_list = list(glob.iglob(os.path.join(OUTPUT_FOLDER, '*.txt')))
-if len(output_list) > 0 and max(os.path.getmtime(path) for path in output_list) >= latest_src:
+os.makedirs(OUTPUT_FOLDER, exist_ok=True)
+src_times = [os.path.getmtime(path) for path in glob.iglob(os.path.join(REPO_PATH, '**/*.json'), recursive=True)]
+dst_times = [os.path.getmtime(path) for path in glob.iglob(os.path.join(OUTPUT_FOLDER, '*.txt'))]
+if dst_times and max(dst_times) >= max(src_times):
     print(f'No changes found')
     exit()
 

--- a/scripts/remote_go.py
+++ b/scripts/remote_go.py
@@ -10,6 +10,7 @@ RELEASE_FOLDER = os.path.join(REPO_PATH, "Release")
 REMOTE_FOLDER = os.path.join(REPO_PATH, "Remote")
 OUTPUT_FOLDER = "./corpus/GO"
 
+os.makedirs(OUTPUT_FOLDER, exist_ok=True)
 
 def convert_lang(lang: str) -> str:
     match lang:
@@ -36,8 +37,8 @@ subprocess.run(['git', 'pull'], cwd=REPO_PATH, check=True)
 
 # Check modified time
 latest_src = max(os.path.getmtime(path) for path in glob.iglob(os.path.join(REPO_PATH, '**/*.json'), recursive=True))
-latest_dst = max(os.path.getmtime(path) for path in glob.iglob(os.path.join(OUTPUT_FOLDER, '*.txt')))
-if latest_dst >= latest_src:
+output_list = list(glob.iglob(os.path.join(OUTPUT_FOLDER, '*.txt')))
+if len(output_list) > 0 and max(os.path.getmtime(path) for path in output_list) >= latest_src:
     print(f'No changes found')
     exit()
 

--- a/scripts/remote_home.py
+++ b/scripts/remote_home.py
@@ -7,6 +7,7 @@ REPO_URL = "https://github.com/sora10pls/megaturtle-text.git"
 REPO_PATH = "./remote/megaturtle-text"
 OUTPUT_FOLDER = "./corpus/HOME"
 
+os.makedirs(OUTPUT_FOLDER, exist_ok=True)
 
 def convert_lang(lang: str) -> str:
     lang_codes = {
@@ -53,8 +54,8 @@ subprocess.run(['git', 'pull'], cwd=REPO_PATH, check=True)
 
 # Check modified time
 latest_src = max(os.path.getmtime(path) for path in glob.iglob(os.path.join(REPO_PATH, '**/msbt_*_lf.txt'), recursive=True))
-latest_dst = max(os.path.getmtime(path) for path in glob.iglob(os.path.join(OUTPUT_FOLDER, '*_megaturtle_sp.txt')))
-if latest_dst >= latest_src:
+output_list = list(glob.iglob(os.path.join(OUTPUT_FOLDER, '*_megaturtle_sp.txt')))
+if len(output_list) > 0 and max(os.path.getmtime(path) for path in output_list) >= latest_src:
     print(f'No changes found')
     exit()
 

--- a/scripts/remote_home.py
+++ b/scripts/remote_home.py
@@ -7,7 +7,6 @@ REPO_URL = "https://github.com/sora10pls/megaturtle-text.git"
 REPO_PATH = "./remote/megaturtle-text"
 OUTPUT_FOLDER = "./corpus/HOME"
 
-os.makedirs(OUTPUT_FOLDER, exist_ok=True)
 
 def convert_lang(lang: str) -> str:
     lang_codes = {
@@ -53,9 +52,10 @@ print(f'Checking if repository is up to date...')
 subprocess.run(['git', 'pull'], cwd=REPO_PATH, check=True)
 
 # Check modified time
-latest_src = max(os.path.getmtime(path) for path in glob.iglob(os.path.join(REPO_PATH, '**/msbt_*_lf.txt'), recursive=True))
-output_list = list(glob.iglob(os.path.join(OUTPUT_FOLDER, '*_megaturtle_sp.txt')))
-if len(output_list) > 0 and max(os.path.getmtime(path) for path in output_list) >= latest_src:
+os.makedirs(OUTPUT_FOLDER, exist_ok=True)
+src_times = [os.path.getmtime(path) for path in glob.iglob(os.path.join(REPO_PATH, '**/msbt_*_lf.txt'), recursive=True)]
+dst_times = [os.path.getmtime(path) for path in glob.iglob(os.path.join(OUTPUT_FOLDER, '*_megaturtle_sp.txt'))]
+if dst_times and max(dst_times) >= max(src_times):
     print(f'No changes found')
     exit()
 

--- a/scripts/remote_masters.py
+++ b/scripts/remote_masters.py
@@ -13,7 +13,6 @@ INPUT_FOLDERS = [
 ]
 OUTPUT_FOLDER = "./corpus/Masters"
 
-os.makedirs(OUTPUT_FOLDER, exist_ok=True)
 
 def convert_lang(lang: str) -> str:
     match lang:
@@ -42,9 +41,10 @@ print(f'Checking if repository is up to date...')
 subprocess.run(['git', 'pull'], cwd=REPO_PATH, check=True)
 
 # Check modified time
-latest_src = max(os.path.getmtime(path) for path in glob.iglob(os.path.join(REPO_PATH, '**/*.json'), recursive=True))
-output_list = list(glob.iglob(os.path.join(OUTPUT_FOLDER, '*.txt')))
-if len(output_list) > 0 and max(os.path.getmtime(path) for path in output_list) >= latest_src:
+os.makedirs(OUTPUT_FOLDER, exist_ok=True)
+src_times = [os.path.getmtime(path) for path in glob.iglob(os.path.join(REPO_PATH, '**/*.json'), recursive=True)]
+dst_times = [os.path.getmtime(path) for path in glob.iglob(os.path.join(OUTPUT_FOLDER, '*.txt'))]
+if dst_times and max(dst_times) >= max(src_times):
     print(f'No changes found')
     exit()
 

--- a/scripts/remote_masters.py
+++ b/scripts/remote_masters.py
@@ -13,6 +13,7 @@ INPUT_FOLDERS = [
 ]
 OUTPUT_FOLDER = "./corpus/Masters"
 
+os.makedirs(OUTPUT_FOLDER, exist_ok=True)
 
 def convert_lang(lang: str) -> str:
     match lang:
@@ -42,8 +43,8 @@ subprocess.run(['git', 'pull'], cwd=REPO_PATH, check=True)
 
 # Check modified time
 latest_src = max(os.path.getmtime(path) for path in glob.iglob(os.path.join(REPO_PATH, '**/*.json'), recursive=True))
-latest_dst = max(os.path.getmtime(path) for path in glob.iglob(os.path.join(OUTPUT_FOLDER, '*.txt')))
-if latest_dst >= latest_src:
+output_list = list(glob.iglob(os.path.join(OUTPUT_FOLDER, '*.txt')))
+if len(output_list) > 0 and max(os.path.getmtime(path) for path in output_list) >= latest_src:
     print(f'No changes found')
     exit()
 


### PR DESCRIPTION
I hit a few issues with a fresh run of all the `scripts/remote_*.py` scripts. They all seemed to assume there was an older version of the files already present in `corpus/<GAME>`, when in fact these directories would not exist at all. This manifested both in an empty set of file timestamps to be passed to `max()`, and also some file access errors later on if the directory wasn't created first.